### PR TITLE
Bump gren-lang/node dependency

### DIFF
--- a/gren.json
+++ b/gren.json
@@ -9,7 +9,7 @@
     "gren-version": "0.3.0 <= v < 0.4.0",
     "dependencies": {
         "gren-lang/core": "4.0.0 <= v < 5.0.0",
-        "gren-lang/node": "2.0.0 <= v < 3.0.0",
+        "gren-lang/node": "3.0.0 <= v < 4.0.0",
         "gren-lang/test": "2.0.0 <= v < 3.0.0"
     }
 }


### PR DESCRIPTION
Current version of `gren-lang/node` is `3.0.1`