### PR TITLE
Add missing import to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A minimal test program will have the following in a Main.gren file:
 ```gren
 module Main exposing (main)
 
+import Expect
 import Test exposing (describe, test)
 import Test.Runner.Node exposing (Program, run)
 


### PR DESCRIPTION
copy/paste from the README will fail without this import