### PR TITLE
Add color to pass/fail output

### DIFF
--- a/src/Test/Runner/Log.gren
+++ b/src/Test/Runner/Log.gren
@@ -25,7 +25,14 @@ import Bytes exposing (Bytes)
 type alias OutputStreams =
     { reportStreamOnPass : Stream.Writable Bytes
     , reportStreamOnFail : Stream.Writable Bytes
+    , colorDepth : Int
     }
+
+
+type Color
+    = NoColor
+    | Green
+    | Red
 
 
 {-| Run the test using the provided options.
@@ -36,20 +43,23 @@ runWithOptions streams runs seed test =
         |> logOutput streams
  
 
-summarize : Summary -> String
-summarize { output, passed, failed, autoFail } =
+summarize : Summary -> Int -> String
+summarize { output, passed, failed, autoFail } colorDepth =
     let
         headline =
             if failed > 0 then
                 "TEST RUN FAILED"
+                    |> colorize colorDepth Red
 
             else
                 when autoFail is
                     Nothing ->
                         "TEST RUN PASSED"
+                            |> colorize colorDepth Green
 
                     Just reason ->
                         "TEST RUN FAILED because " ++ reason
+                            |> colorize colorDepth Red
     in
     String.join "\n"
         [ output
@@ -63,7 +73,7 @@ logOutput : OutputStreams -> Summary -> Task Never {}
 logOutput streams summary =
     let
         output =
-            summarize summary
+            summarize summary streams.colorDepth
 
         { printStream, exitCode } =
             if summary.failed > 0 || summary.autoFail /= Nothing then
@@ -80,3 +90,31 @@ logOutput streams summary =
         |> Task.andThen (\_ -> Node.exitWithCode exitCode)
         |> Task.onError (\_ -> Node.exitWithCode 1)
 
+
+colorize : Int -> Color -> String -> String
+colorize colorDepth color string =
+    if colorDepth > 1 then
+        String.join ""
+            [ setColor color
+            , string
+            , setColor NoColor
+            ]
+    else
+        string
+
+
+setColor : Color -> String
+setColor color =
+    String.join ""
+        [ "\u{001b}["
+        , colorCode color
+        , "m"
+        ]
+
+
+colorCode : Color -> String
+colorCode color =
+    when color is
+        NoColor -> "39"
+        Green -> "32"
+        Red -> "31"

--- a/src/Test/Runner/Node.gren
+++ b/src/Test/Runner/Node.gren
@@ -17,6 +17,7 @@ import Node
 import Init
 import Test.Runner.Log as Log
 import Random
+import Terminal
 import Time
 
 
@@ -35,10 +36,12 @@ run : Test -> Program
 run test =
     Node.defineSimpleProgram <| \env ->
         Init.awaitTask Time.now <| \time ->
+        Init.await Terminal.initialize <| \termConfig ->
             Node.endSimpleProgram <|
                 Log.runWithOptions
                     { reportStreamOnPass = env.stdout
                     , reportStreamOnFail = env.stderr
+                    , colorDepth = getColorDepth termConfig
                     }
                     100
                     (Random.initialSeed (Time.posixToMillis time))
@@ -65,12 +68,23 @@ type alias Options =
 runWithOptions : Options -> Test -> Program
 runWithOptions options test =
     Node.defineSimpleProgram <| \env ->
-        Node.endSimpleProgram <|
-            Log.runWithOptions
-                { reportStreamOnPass = env.stdout
-                , reportStreamOnFail = env.stderr
-                }
-                options.runs
-                options.seed
-                test
+        Init.await Terminal.initialize <| \termConfig ->
+            Node.endSimpleProgram <|
+                Log.runWithOptions
+                    { reportStreamOnPass = env.stdout
+                    , reportStreamOnFail = env.stderr
+                    , colorDepth = getColorDepth termConfig
+                    }
+                    options.runs
+                    options.seed
+                    test
            
+
+getColorDepth : Maybe Terminal.Configuration -> Int
+getColorDepth config =
+    when config is
+        Just { colorDepth } ->
+            colorDepth
+        Nothing ->
+            1 -- lowest color depth (no colors)
+


### PR DESCRIPTION
Confirmed this is showing red/green when run normally in my terminal, but no color if redirecting to a file, pipe, or setting `NO_COLOR=1` or `FORCE_COLOR=0` manually.